### PR TITLE
Code change for the given requirement with AI:  remediation_branch-2025-06-06_15-21 -> integration-failure

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/system/CrashController.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/CrashController.java
@@ -30,8 +30,7 @@ class CrashController {
 
 	@GetMapping("/oups")
 	public String triggerException() {
-		throw new RuntimeException(
-				"Expected: controller used to showcase what " + "happens when an exception is thrown!");
+		throw new RuntimeException("Expected: controller used to showcase what happens when an exception is thrown");
 	}
 
 }


### PR DESCRIPTION

            Fix build errors:
            
=== Build Errors ===
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.775 s <<< FAILURE! -- in org.springframework.samples.petclinic.system.CrashControllerIntegrationTests
[ERROR] org.springframework.samples.petclinic.system.CrashControllerIntegrationTests.testTriggerExceptionJson -- Time elapsed: 0.186 s <<< FAILURE!
java.lang.AssertionError:

Expecting map:
{"error"="Internal Server Error", "message"="Expected: controller used to showcase what happens when an exception is thrown!", "path"="/oups", "status"=500, "timestamp"="2025-06-06T15:23:47.201+00:00"}
to contain entries:
["message"="Expected: controller used to showcase what happens when an exception is thrown"]
but the following map entries had different values:
["message"="Expected: controller used to showcase what happens when an exception is thrown!" (expected: "Expected: controller used to showcase what happens when an exception is thrown")]
at org.springframework.samples.petclinic.system.CrashControllerIntegrationTests.testTriggerExceptionJson(CrashControllerIntegrationTests.java:76)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

[ERROR] Failures:
[ERROR]   CrashControllerIntegrationTests.testTriggerExceptionJson:76
Expecting map:
{"error"="Internal Server Error", "message"="Expected: controller used to showcase what happens when an exception is thrown!", "path"="/oups", "status"=500, "timestamp"="2025-06-06T15:23:47.201+00:00"}
to contain entries:
["message"="Expected: controller used to showcase what happens when an exception is thrown"]
but the following map entries had different values:
["message"="Expected: controller used to showcase what happens when an exception is thrown!" (expected: "Expected: controller used to showcase what happens when an exception is thrown")]
[ERROR] Tests run: 45, Failures: 1, Errors: 0, Skipped: 2
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.5:test (default-test) on project spring-petclinic: There are test failures.
[ERROR]
[ERROR] Please refer to /home/jenkins/agent/workspace/ediation_branch-2025-06-06_15-21/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
ERROR: script returned exit code 1

Could not update commit status, please check if your scan credentials belong to a member of the organization or a collaborator of the repository and repo:status scope is selected


GitHub has been notified of this commit’s build result

Finished: FAILURE
=======================
            