### PR TITLE
Code change for the given requirement with AI:  remediation_branch-2025-06-26_14-56 -> test-failure

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -129,7 +129,7 @@ class OwnerControllerTests {
 			.andExpect(model().attributeHasErrors("owner"))
 			.andExpect(model().attributeHasFieldErrors("owner", "address"))
 			.andExpect(model().attributeHasFieldErrors("owner", "telephone"))
-			.andExpect(view().name("owners/createOrUpdateOwnerFo"));
+			.andExpect(view().name("owners/createOrUpdateOwnerForm"));
 	}
 
 	@Test


### PR DESCRIPTION

            Fix build errors:
            
=== Build Errors ===
[ERROR] Tests run: 12, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.073 s <<< FAILURE! -- in org.springframework.samples.petclinic.owner.OwnerControllerTests
[ERROR] org.springframework.samples.petclinic.owner.OwnerControllerTests.testProcessCreationFormHasErrors -- Time elapsed: 0.034 s <<< FAILURE!
java.lang.AssertionError: View name expected:<owners/createOrUpdateOwnerFo> but was:<owners/createOrUpdateOwnerForm>
at org.springframework.test.util.AssertionErrors.fail(AssertionErrors.java:59)
at org.springframework.test.util.AssertionErrors.assertEquals(AssertionErrors.java:122)
at org.springframework.test.web.servlet.result.ViewResultMatchers.lambda$name$1(ViewResultMatchers.java:69)
at org.springframework.test.web.servlet.MockMvc$1.andExpect(MockMvc.java:214)
at org.springframework.samples.petclinic.owner.OwnerControllerTests.testProcessCreationFormHasErrors(OwnerControllerTests.java:132)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

[ERROR] Failures:
[ERROR]   OwnerControllerTests.testProcessCreationFormHasErrors:132 View name expected:<owners/createOrUpdateOwnerFo> but was:<owners/createOrUpdateOwnerForm>
[ERROR] Tests run: 45, Failures: 1, Errors: 0, Skipped: 2
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.5:test (default-test) on project spring-petclinic: There are test failures.
[ERROR]
[ERROR] Please refer to /home/jenkins/agent/workspace/ediation_branch-2025-06-26_14-56/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
ERROR: script returned exit code 1

Could not update commit status, please check if your scan credentials belong to a member of the organization or a collaborator of the repository and repo:status scope is selected


GitHub has been notified of this commit’s build result

Finished: FAILURE
=======================
            