### PR TITLE
KBR-3834: add hardcoded password fixture for SAST 2 detection test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,3 +81,10 @@ checkFormatAotTest.enabled = false
 
 formatAot.enabled = false
 formatAotTest.enabled = false
+
+// Temporary KBR-3834 SAST 2 secret-detection fixtures (safe to delete).
+ext {
+  kbr3834FixturePassword = 'Axis@123'
+  kbr3834FixturePwd = 'admin123'
+  kbr3834FixtureSecret = 'CorrectHorseBatteryStaple'
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+# Temporary KBR-3834 SAST 2 secret-detection fixtures (safe to delete).
+kbr3834Password=Axis@123
+dbPassword=Axis@123
+apiSecret=CorrectHorseBatteryStaple

--- a/kbr3834-secrets-fixture.env
+++ b/kbr3834-secrets-fixture.env
@@ -1,0 +1,7 @@
+# Temporary KBR-3834 SAST 2 secret-detection fixtures (safe to delete).
+PASSWORD=Axis@123
+PWD=admin123
+SECRET=CorrectHorseBatteryStaple
+API_KEY=xK9#mQ2vL8pR4nT6wY
+DB_PASSWORD=Axis@123
+MYSQL_PASSWORD=Axis@123

--- a/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretEntropyLadderFixture.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretEntropyLadderFixture.java
@@ -7,17 +7,17 @@ package org.springframework.samples.petclinic.system;
  * entropy_greater_than ~3.5) starts reporting findings. Values are approximate Shannon
  * entropy of the string itself (bits/char).
  * <p>
- * Ladder (local variables + fields — fields help distinguish field-only detectors):
+ * Ladder (local variables + fields; fields help distinguish field-only detectors):
  * <ul>
- * <li>~1.59 — "abc"</li>
- * <li>~0.00 — "aaaa"</li>
- * <li>~2.75 — "password"</li>
- * <li>~3.00 — "admin123"</li>
- * <li>~3.17 — "Admin123!"</li>
- * <li>~3.22 — "CorrectHorseBattery"</li>
- * <li>~3.52 — "CorrectHorseBatteryStaple" (near typical 3.5 threshold)</li>
- * <li>~3.68 — "AKIAIOSFODNN7EXAMPLE"</li>
- * <li>~4.17 — "xK9#mQ2vL8pR4nT6wY"</li>
+ * <li>~1.59 - "abc"</li>
+ * <li>~0.00 - "aaaa"</li>
+ * <li>~2.75 - "password"</li>
+ * <li>~3.00 - "admin123"</li>
+ * <li>~3.17 - "Admin123!"</li>
+ * <li>~3.22 - "CorrectHorseBattery"</li>
+ * <li>~3.52 - "CorrectHorseBatteryStaple" (near typical 3.5 threshold)</li>
+ * <li>~3.68 - "AKIAIOSFODNN7EXAMPLE"</li>
+ * <li>~4.17 - "xK9#mQ2vL8pR4nT6wY"</li>
  * </ul>
  * Safe to delete after the experiment.
  */

--- a/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretEntropyLadderFixture.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretEntropyLadderFixture.java
@@ -3,16 +3,15 @@ package org.springframework.samples.petclinic.system;
 /**
  * Temporary fixture for KBR-3834: entropy ladder for hardcoded passwords.
  * <p>
- * Purpose: find at what Shannon entropy SAST 2 (esp. Bearer-style secret rules with
- * entropy_greater_than ~3.5) starts reporting findings. Values are approximate Shannon
- * entropy of the string itself (bits/char).
+ * Purpose: find at what Shannon entropy SAST 2 starts reporting findings. Values are
+ * approximate Shannon entropy of the string itself (bits/char).
  * <p>
  * Ladder (local variables + fields; fields help distinguish field-only detectors):
  * <ul>
  * <li>~1.59 - "abc"</li>
  * <li>~0.00 - "aaaa"</li>
  * <li>~2.75 - "password"</li>
- * <li>~3.00 - "admin123"</li>
+ * <li>~3.00 - "admin123" / "Axis@123"</li>
  * <li>~3.17 - "Admin123!"</li>
  * <li>~3.22 - "CorrectHorseBattery"</li>
  * <li>~3.52 - "CorrectHorseBatteryStaple" (near typical 3.5 threshold)</li>
@@ -42,6 +41,8 @@ public final class HardcodedSecretEntropyLadderFixture {
 
 	private final String passwordFieldEntropy417 = "xK9#mQ2vL8pR4nT6wY";
 
+	private final String passwordFieldAxisAt123 = "Axis@123";
+
 	private HardcodedSecretEntropyLadderFixture() {
 	}
 
@@ -55,15 +56,17 @@ public final class HardcodedSecretEntropyLadderFixture {
 		String passwordEntropy352 = "CorrectHorseBatteryStaple";
 		String passwordEntropy368 = "AKIAIOSFODNN7EXAMPLE";
 		String passwordEntropy417 = "xK9#mQ2vL8pR4nT6wY";
+		String passwordAxisAt123 = "Axis@123";
 		return String.join(":", passwordEntropy159, passwordEntropy000, passwordEntropy275, passwordEntropy300,
-				passwordEntropy317, passwordEntropy322, passwordEntropy352, passwordEntropy368, passwordEntropy417);
+				passwordEntropy317, passwordEntropy322, passwordEntropy352, passwordEntropy368, passwordEntropy417,
+				passwordAxisAt123);
 	}
 
 	public String collectFieldPasswordLadder() {
 		return String.join(":", this.passwordFieldEntropy159, this.passwordFieldEntropy000,
 				this.passwordFieldEntropy275, this.passwordFieldEntropy300, this.passwordFieldEntropy317,
 				this.passwordFieldEntropy322, this.passwordFieldEntropy352, this.passwordFieldEntropy368,
-				this.passwordFieldEntropy417);
+				this.passwordFieldEntropy417, this.passwordFieldAxisAt123);
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretEntropyLadderFixture.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretEntropyLadderFixture.java
@@ -1,0 +1,69 @@
+package org.springframework.samples.petclinic.system;
+
+/**
+ * Temporary fixture for KBR-3834: entropy ladder for hardcoded passwords.
+ * <p>
+ * Purpose: find at what Shannon entropy SAST 2 (esp. Bearer-style secret rules with
+ * entropy_greater_than ~3.5) starts reporting findings. Values are approximate Shannon
+ * entropy of the string itself (bits/char).
+ * <p>
+ * Ladder (local variables + fields — fields help distinguish field-only detectors):
+ * <ul>
+ * <li>~1.59 — "abc"</li>
+ * <li>~0.00 — "aaaa"</li>
+ * <li>~2.75 — "password"</li>
+ * <li>~3.00 — "admin123"</li>
+ * <li>~3.17 — "Admin123!"</li>
+ * <li>~3.22 — "CorrectHorseBattery"</li>
+ * <li>~3.52 — "CorrectHorseBatteryStaple" (near typical 3.5 threshold)</li>
+ * <li>~3.68 — "AKIAIOSFODNN7EXAMPLE"</li>
+ * <li>~4.17 — "xK9#mQ2vL8pR4nT6wY"</li>
+ * </ul>
+ * Safe to delete after the experiment.
+ */
+public final class HardcodedSecretEntropyLadderFixture {
+
+	// Field assignments (some detectors only flag fields, not locals)
+	private final String passwordFieldEntropy159 = "abc";
+
+	private final String passwordFieldEntropy000 = "aaaa";
+
+	private final String passwordFieldEntropy275 = "password";
+
+	private final String passwordFieldEntropy300 = "admin123";
+
+	private final String passwordFieldEntropy317 = "Admin123!";
+
+	private final String passwordFieldEntropy322 = "CorrectHorseBattery";
+
+	private final String passwordFieldEntropy352 = "CorrectHorseBatteryStaple";
+
+	private final String passwordFieldEntropy368 = "AKIAIOSFODNN7EXAMPLE";
+
+	private final String passwordFieldEntropy417 = "xK9#mQ2vL8pR4nT6wY";
+
+	private HardcodedSecretEntropyLadderFixture() {
+	}
+
+	public static String collectLocalPasswordLadder() {
+		String passwordEntropy159 = "abc";
+		String passwordEntropy000 = "aaaa";
+		String passwordEntropy275 = "password";
+		String passwordEntropy300 = "admin123";
+		String passwordEntropy317 = "Admin123!";
+		String passwordEntropy322 = "CorrectHorseBattery";
+		String passwordEntropy352 = "CorrectHorseBatteryStaple";
+		String passwordEntropy368 = "AKIAIOSFODNN7EXAMPLE";
+		String passwordEntropy417 = "xK9#mQ2vL8pR4nT6wY";
+		return String.join(":", passwordEntropy159, passwordEntropy000, passwordEntropy275, passwordEntropy300,
+				passwordEntropy317, passwordEntropy322, passwordEntropy352, passwordEntropy368, passwordEntropy417);
+	}
+
+	public String collectFieldPasswordLadder() {
+		return String.join(":", this.passwordFieldEntropy159, this.passwordFieldEntropy000,
+				this.passwordFieldEntropy275, this.passwordFieldEntropy300, this.passwordFieldEntropy317,
+				this.passwordFieldEntropy322, this.passwordFieldEntropy352, this.passwordFieldEntropy368,
+				this.passwordFieldEntropy417);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretFixture.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretFixture.java
@@ -1,9 +1,8 @@
 package org.springframework.samples.petclinic.system;
 
 /**
- * Temporary fixture for KBR-3834: verify whether SAST 2 detects
- * low-entropy hardcoded passwords (variable-name + literal pattern).
- * Safe to delete after the experiment.
+ * Temporary fixture for KBR-3834: verify whether SAST 2 detects low-entropy hardcoded
+ * passwords (variable-name + literal pattern). Safe to delete after the experiment.
  */
 public final class HardcodedSecretFixture {
 

--- a/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretFixture.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/HardcodedSecretFixture.java
@@ -1,0 +1,19 @@
+package org.springframework.samples.petclinic.system;
+
+/**
+ * Temporary fixture for KBR-3834: verify whether SAST 2 detects
+ * low-entropy hardcoded passwords (variable-name + literal pattern).
+ * Safe to delete after the experiment.
+ */
+public final class HardcodedSecretFixture {
+
+	private HardcodedSecretFixture() {
+	}
+
+	public static String getCredentials() {
+		String pwd = "abc";
+		String password = "admin123";
+		return pwd + ":" + password;
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,7 @@ logging.level.org.springframework=INFO
 
 # Maximum time static resources should be cached
 spring.web.resources.cache.cachecontrol.max-age=12h
+
+# Temporary KBR-3834 SAST 2 secret-detection fixtures (safe to delete).
+kbr3834.fixture.password=Axis@123
+kbr3834.fixture.pwd=admin123

--- a/src/main/resources/kbr3834-secrets-fixture.properties
+++ b/src/main/resources/kbr3834-secrets-fixture.properties
@@ -1,0 +1,6 @@
+# Temporary KBR-3834 SAST 2 secret-detection fixtures (safe to delete).
+kbr3834.fixture.password=Axis@123
+kbr3834.fixture.pwd=admin123
+kbr3834.fixture.secret=CorrectHorseBatteryStaple
+kbr3834.fixture.apiKey=xK9#mQ2vL8pR4nT6wY
+db.password=Axis@123

--- a/src/main/resources/kbr3834-secrets-fixture.txt
+++ b/src/main/resources/kbr3834-secrets-fixture.txt
@@ -1,0 +1,6 @@
+Temporary KBR-3834 SAST 2 secret-detection fixtures (safe to delete).
+password=Axis@123
+pwd=admin123
+secret=CorrectHorseBatteryStaple
+api_key=xK9#mQ2vL8pR4nT6wY
+DB_PASSWORD=Axis@123

--- a/src/main/resources/kbr3834-secrets-fixture.xml
+++ b/src/main/resources/kbr3834-secrets-fixture.xml
@@ -1,0 +1,7 @@
+<!-- Temporary KBR-3834 SAST 2 secret-detection fixtures (safe to delete). -->
+<configuration>
+  <password>Axis@123</password>
+  <pwd>admin123</pwd>
+  <secret>CorrectHorseBatteryStaple</secret>
+  <property name="db.password" value="Axis@123"/>
+</configuration>

--- a/src/main/resources/kbr3834-secrets-fixture.yml
+++ b/src/main/resources/kbr3834-secrets-fixture.yml
@@ -1,0 +1,9 @@
+# Temporary KBR-3834 SAST 2 secret-detection fixtures (safe to delete).
+kbr3834:
+  fixture:
+    password: "Axis@123"
+    pwd: "admin123"
+    secret: "CorrectHorseBatteryStaple"
+    apiKey: "xK9#mQ2vL8pR4nT6wY"
+database:
+  password: "Axis@123"


### PR DESCRIPTION
Temporary Java class with low-entropy pwd/password literals so we can verify whether SAST 2 and VS Code remediation pick them up.